### PR TITLE
Grovel define-library for (include "...")

### DIFF
--- a/live.egg
+++ b/live.egg
@@ -41,19 +41,19 @@
    (extension
      live.list.unstable
      (source "live/list/unstable.sld")
-     (source-dependencies)
+     (source-dependencies "live/list/live.scm")
      (component-dependencies)
      (csc-options "-R" "r7rs" "-X" "r7rs"))
    (extension
      live.net.gemini.unstable
      (source "live/net/gemini/unstable.sld")
-     (source-dependencies)
+     (source-dependencies "live/net/gemini/live.scm")
      (component-dependencies)
      (csc-options "-R" "r7rs" "-X" "r7rs"))
    (extension
      live.net.gemini.client.unstable
      (source "live/net/gemini/client/unstable.sld")
-     (source-dependencies)
+     (source-dependencies "live/net/gemini/client/live.scm")
      (component-dependencies)
      (csc-options "-R" "r7rs" "-X" "r7rs"))
    (extension
@@ -65,7 +65,7 @@
    (extension
      live.string.unstable
      (source "live/string/unstable.sld")
-     (source-dependencies)
+     (source-dependencies "live/string/live.scm" "live/string/srfi-13.scm")
      (component-dependencies)
      (csc-options "-R" "r7rs" "-X" "r7rs"))
    (extension

--- a/live.egg
+++ b/live.egg
@@ -23,7 +23,6 @@
    "live/number/unstable.sld"
    "live/string/unstable.sld"
    "live/string/live.scm"
-   "live/string/srfi-13.scm"
    "live/time/iso/unstable.sld")
  (components
    (extension
@@ -65,7 +64,7 @@
    (extension
      live.string.unstable
      (source "live/string/unstable.sld")
-     (source-dependencies "live/string/live.scm" "live/string/srfi-13.scm")
+     (source-dependencies "live/string/live.scm")
      (component-dependencies)
      (csc-options "-R" "r7rs" "-X" "r7rs"))
    (extension

--- a/live.egg
+++ b/live.egg
@@ -15,10 +15,15 @@
    "live/bitwise/unstable.sld"
    "live/fixnum/unstable.sld"
    "live/list/unstable.sld"
+   "live/list/live.scm"
    "live/net/gemini/unstable.sld"
+   "live/net/gemini/live.scm"
    "live/net/gemini/client/unstable.sld"
+   "live/net/gemini/client/live.scm"
    "live/number/unstable.sld"
    "live/string/unstable.sld"
+   "live/string/live.scm"
+   "live/string/srfi-13.scm"
    "live/time/iso/unstable.sld")
  (components
    (extension

--- a/scripts/generate-wrappers.scm
+++ b/scripts/generate-wrappers.scm
@@ -154,10 +154,10 @@
          (components
           ,@(append-map
              (lambda (lib)
-               (map (lambda (libname)
+               (map (lambda (lib-name)
                       `(extension
-                        ,(library-name->chicken libname)
-                        (source ,(library-name->sld libname))
+                        ,(library-name->chicken lib-name)
+                        (source ,(library-name->sld lib-name))
                         (source-dependencies
                          ,@(map library-name->sld (mine 'include lib)))
                         (component-dependencies


### PR DESCRIPTION
Here's the first draft of the library groveler in `generate-wrappers.scm`.

It finds all instances `(include "...")` and writes a list of the included files into `live.egg`.

The `define-library` parser is as dumb as possible. It finds any list that looks like `(include "...")`.