### PR TITLE
Dockerfile++

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,13 @@
 # -*- mode: dockerfile; coding: utf-8 -*-
-FROM ubuntu:20.04
-
-ADD . /live
+FROM debian:bullseye
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt upgrade && apt install --yes git
-RUN cd /live && git clean -fxd
+RUN apt update && apt upgrade --yes && apt install --yes git make
+RUN git clone https://github.com/scheme-live/live.git
 
-ENV USER=star
+RUN cd /live && make prepare-debian
 
-RUN apt install --yes make && cd /live && make prepare-debian
+RUN cd /live && ./venv scheme-live install /
 
-RUN cd /live && rm -rf local/opt && ./venv scheme-live install
-
-run rm -rf /var/cache/apt/* /tmp
-RUN mkdir /tmp
-
-CMD ["bash"]
+RUN rm -rf /var/cache/apt/* /tmp && make /tmp

--- a/local/bin/scheme-live
+++ b/local/bin/scheme-live
@@ -34,7 +34,7 @@ scheme-live-available () {
 }
 
 scheme-live-install () {
-    scheme-live available | xargs -i scheme-live {} install
+    scheme-live available | xargs -i scheme-live {} install $1
 }
 
 scheme-live-check () {

--- a/venv
+++ b/venv
@@ -8,10 +8,14 @@ set -e
 if test -d "$(pwd)/.git"; then
     if [[ -z "$SCHEME_LIVE_VENV" ]]; then
         export SCHEME_LIVE_VENV=yes
-        export SCHEME_LIVE_PREFIX=$(pwd)/local
         export SCHEME_LIVE_CORE_COUNT=$(nproc --ignore=1)
+        if test -d $1; then
+            export SCHEME_LIVE_PREFIX=$1
+            shift
+        else
+            export SCHEME_LIVE_PREFIX=$(pwd)/local
+        fi
         export PATH="$SCHEME_LIVE_PREFIX/bin:$HOME/.local/bin:$PATH"
-
         if [[ -z "$@" ]]; then
             echo "Entering scheme-live environment..."
             $SHELL


### PR DESCRIPTION
- use debian bullseye
- clone scheme-live repository from git
- compile and install via`scheme-live` with `/` as prefix, hence scheme are installed inside `/opt/live/`
- venv: tentative to make it work inside `Dockerfile`